### PR TITLE
v0.0.2 - specify mongo collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [v0.0.2]
+
+### Added
+- Include new database options for entity, including the ability to specify the collection name. If no collection name is provided the entity name is used as default mongo collection name value.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subgraph"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [dependencies]
@@ -27,7 +27,4 @@ toml = "0.5.6"
 version = "2.3.1"
 default-features = false
 features = ["tokio-runtime"]
-
-# [target.x86_64-unknown-linux-gnu]
-# rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ mongo_db = "myDb"
 [[service.entities]]
 name = "Dog"
 
+[service.entities.database_config]
+mongo_collection = "dogs"
+
 [[service.entities.fields]]
 name = "name"
 scalar = "string"
@@ -67,7 +70,7 @@ Simple TOML configuration to define the entities to be resolved.
 
 Resolvers are created for each defined entity.
 
-- Create Many
+- Create One
 - Find One
 
 ### Sandbox
@@ -99,12 +102,15 @@ Once started, view the sandbox in the browser hosted at the specified port. For 
 | mongo_uri       | String |
 | mongo_db        | String |
 
-| Entity |         |
-| ------ | ------- |
-| key    | value   |
-| ------ | ------- |
-| name   | String  |
-| fields | Field[] |
+| Entity         |                     |
+| -------------- | ------------------- |
+| name           | String              |
+| fields         | Field[]             |
+| datbase_config | EntityDatbaseConfig |
+
+| EntityDatabaseConfig |        |
+| -------------------- | ------ |
+| mongo_collection     | String |
 
 | Field    |         |
 | -------- | ------- |

--- a/src/configuration/subgraph/mod.rs
+++ b/src/configuration/subgraph/mod.rs
@@ -19,9 +19,15 @@ pub struct ServiceEntityFieldOptions {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ServiceEntityDatabaseConfig {
+    pub mongo_collection: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ServiceEntity {
     pub name: String,
     pub fields: Vec<ServiceEntityFieldOptions>,
+    pub database_config: Option<ServiceEntityDatabaseConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/database/services/create_one/mod.rs
+++ b/src/database/services/create_one/mod.rs
@@ -9,8 +9,9 @@ impl Services {
     pub async fn create_one(
         db: Database,
         new_struct: Document,
+        collection: String,
     ) -> Result<Document, async_graphql::Error> {
-        let coll = db.collection::<Document>("users");
+        let coll = db.collection::<Document>(&collection);
 
         let document = to_document(&new_struct).unwrap();
 

--- a/src/database/services/find_many/mod.rs
+++ b/src/database/services/find_many/mod.rs
@@ -1,0 +1,9 @@
+// use bson::Document;
+
+// use super::Services;
+
+// impl Services {
+//     pub async fn find_many() -> Result<Vec<Document>, async_graphql::Error> {
+//         let col = db.collection::<Document>("users");
+//     }
+// }

--- a/src/database/services/find_one/mod.rs
+++ b/src/database/services/find_one/mod.rs
@@ -8,8 +8,9 @@ impl Services {
     pub async fn find_one(
         db: Database,
         filter: Document,
+        collection: String,
     ) -> Result<Document, async_graphql::Error> {
-        let collection = db.collection("users");
+        let collection = db.collection(&collection);
 
         let document = collection.find_one(filter, None).await;
 

--- a/src/database/services/mod.rs
+++ b/src/database/services/mod.rs
@@ -1,5 +1,6 @@
 mod create_many;
 mod create_one;
+mod find_many;
 mod find_one;
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use async_graphql_warp::{GraphQLBadRequest, GraphQLResponse};
 use clap::Parser;
 use env_logger::Env;
 use http::StatusCode;
-use log::{debug, error, info};
+use log::{debug, info};
 use std::convert::Infallible;
 use warp::{http::Response as HttpResponse, Filter, Rejection};
 


### PR DESCRIPTION
# Changelog

## [v0.0.2]

### Added
- Include new database options for entity, including the ability to specify the collection name. If no collection name is provided the entity name is used as default mongo collection name value.