### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "Subgraph is a CLI that instantly generates a GraphQL API around Mongo, SQL, and HTTP APIs."
 homepage = "https://www.thedevoyage.com"
-repository = "https://www.github.com/the-devoyage/subgraph"
+repository = "https://github.com/the-devoyage/subgraph"
 readme = "README.md"
 
 [lib]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
